### PR TITLE
Configure LocalStack to persist data upon restarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,11 @@ dynamo:
 	awslocal dynamodb create-table --cli-input-json file://create-records-table.json --region us-west-2
 
 localstack:
-	localstack start --docker
+	DATA_DIR=/tmp/localstack/data localstack start --docker
 
 setup:
 	go get -u github.com/golang/dep/cmd/dep
+	pip install awscli-local
 
 test:
 	go test -race $(TESTDIRS)

--- a/README.md
+++ b/README.md
@@ -8,15 +8,19 @@ In your Go workspace (`$GOPATH/github.com/blucard/`):
 $ git clone git@github.com:blucard/blucard.git
 ```
 
-### Intital Setup
+### Initial Setup
 ```bash
 $ make setup      # download dependencies
 ```
 
+#### LocalStack Setup
 ```bash
-$ make localstack           # run local AWS stack (run this command in a different window/tab)
-$ pip install awscli-local  # only need to run once
-$ make dynamo               # creates local dynamo tables
+$ make localstack # run local AWS stack (run this command in a different window/tab)
+$ make dynamo     # creates local dynamo tables (only need to run if the table is not already created)
+```
 
+#### Start Server
+```bash
+$ make localstack # run in separate window/tab
 $ make dev        # start local server
 ```


### PR DESCRIPTION
This change should allow LocalStack to persist data in DynamoDB locally between restarts. Data will be saved to `/tmp/localstack/data` in the Docker container and should simply development overhead.